### PR TITLE
fix: province parsing robustness

### DIFF
--- a/scraper/db/supabase_client.py
+++ b/scraper/db/supabase_client.py
@@ -33,10 +33,13 @@ class SupabaseManager:
         region = region.strip().title()
         
         # Cerca esistente
-        result = client.table("locations").select("id").eq("city", city).eq("province", province).execute()
-        
+        result = client.table("locations").select("id, region").eq("city", city).eq("province", province).execute()
+
         if result.data:
-            return result.data[0]["id"]
+            location_id = result.data[0]["id"]
+            if result.data[0]["region"] != region:
+                client.table("locations").update({"region": region}).eq("id", location_id).execute()
+            return location_id
         
         # Inserisci nuovo
         result = client.table("locations").insert({

--- a/scraper/models/provinces.py
+++ b/scraper/models/provinces.py
@@ -112,4 +112,3 @@ class Province(str, Enum):
     VI = "VI"
     VR = "VR"
     VV = "VV"
-    ZA = "ZA"

--- a/scraper/utils/parsers.py
+++ b/scraper/utils/parsers.py
@@ -11,30 +11,40 @@ from scraper.utils.region_mapper import get_region_from_province
 def parse_location(location_raw: str, default_province: Province = Province.BG) -> Location:
     """
     Parse a location string into a Location object.
-    
+
     Args:
         location_raw: Raw location string, e.g. "Spinone al Lago (BG)"
         default_province: Default province if not found in string
-        
+
     Returns:
         Location object with city, province and region
     """
-    parts = location_raw.strip().split()
-    
-    if len(parts) >= 2:
+    raw = location_raw.strip()
+    city = raw
+    province_str = None
+
+    # Priorità al formato esplicito con parentesi: "Città (XX)"
+    m = re.search(r'\(([A-Za-z]{2,3})\)\s*$', raw)
+    if m:
+        province_str = m.group(1).upper()
+        city = raw[:m.start()].strip()
+    elif len(raw.split()) >= 2:
+        # Fallback posizionale: ultimo token senza parentesi, es. "Varese VA"
+        parts = raw.split()
+        province_str = parts[-1].strip("()").upper()
         city = " ".join(parts[:-1])
-        province_str = parts[-1].strip("()").upper()  # rimuove parentesi
-        
+
+    if province_str:
         try:
             province = Province(province_str)
             region = get_region_from_province(province)
             return Location(city=city, province=province, region=region)
         except ValueError:
             print(f"⚠️ Unknown province '{province_str}', defaulting to {default_province.value}")
-    
+
     # Fallback con provincia di default
     region = get_region_from_province(default_province)
-    return Location(city=location_raw.strip(), province=default_province, region=region)
+    return Location(city=raw, province=default_province, region=region)
 
 
 def parse_distances(raw: str) -> List[str]:

--- a/scraper/utils/parsers.py
+++ b/scraper/utils/parsers.py
@@ -8,6 +8,34 @@ from scraper.models.provinces import Province
 from scraper.utils.region_mapper import get_region_from_province
 
 
+def extract_province_str(text: str) -> tuple[str, str | None]:
+    """
+    Estrae città e sigla provincia grezza da una stringa di location.
+
+    Supporta i formati:
+    - "Città (XX)"  — parentesi esplicite in coda (priorità)
+    - "Città XX"    — fallback posizionale, ultimo token
+
+    Args:
+        text: Stringa grezza, es. "Spinone al Lago (BG)" o "Varese VA"
+
+    Returns:
+        Tupla (city, province_str) dove province_str è in uppercase
+        o None se non è stato trovato nessun candidato.
+    """
+    raw = text.strip()
+
+    m = re.search(r'\(([A-Za-z]{2,3})\)\s*$', raw)
+    if m:
+        return raw[:m.start()].strip(), m.group(1).upper()
+
+    parts = raw.split()
+    if len(parts) >= 2:
+        return " ".join(parts[:-1]), parts[-1].strip("()").upper()
+
+    return raw, None
+
+
 def parse_location(location_raw: str, default_province: Province = Province.BG) -> Location:
     """
     Parse a location string into a Location object.
@@ -20,19 +48,7 @@ def parse_location(location_raw: str, default_province: Province = Province.BG) 
         Location object with city, province and region
     """
     raw = location_raw.strip()
-    city = raw
-    province_str = None
-
-    # Priorità al formato esplicito con parentesi: "Città (XX)"
-    m = re.search(r'\(([A-Za-z]{2,3})\)\s*$', raw)
-    if m:
-        province_str = m.group(1).upper()
-        city = raw[:m.start()].strip()
-    elif len(raw.split()) >= 2:
-        # Fallback posizionale: ultimo token senza parentesi, es. "Varese VA"
-        parts = raw.split()
-        province_str = parts[-1].strip("()").upper()
-        city = " ".join(parts[:-1])
+    city, province_str = extract_province_str(raw)
 
     if province_str:
         try:
@@ -42,7 +58,6 @@ def parse_location(location_raw: str, default_province: Province = Province.BG) 
         except ValueError:
             print(f"⚠️ Unknown province '{province_str}', defaulting to {default_province.value}")
 
-    # Fallback con provincia di default
     region = get_region_from_province(default_province)
     return Location(city=raw, province=default_province, region=region)
 

--- a/scraper/utils/region_mapper.py
+++ b/scraper/utils/region_mapper.py
@@ -79,6 +79,7 @@ PROVINCE_TO_REGION = {
     
     # Friuli-Venezia Giulia
     Province.GO: "Friuli-Venezia Giulia",
+    Province.GOR: "Friuli-Venezia Giulia",  # codice non standard usato da FIASP per Gorizia
     Province.PN: "Friuli-Venezia Giulia",
     Province.TS: "Friuli-Venezia Giulia",
     Province.UD: "Friuli-Venezia Giulia",

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -106,6 +106,24 @@ class TestExtractProvinceStr:
         assert prov == expected_prov
 
 
+class TestGORProvince:
+    """Verifica che il codice non-standard GOR (Gorizia) venga gestito correttamente."""
+
+    def test_gor_parsed_from_fiasp_format(self):
+        loc = parse_location("CORMONS (GOR)")
+        assert loc.province == Province.GOR
+        assert loc.region == "Friuli-Venezia Giulia"
+        assert loc.city == "CORMONS"
+
+    def test_gor_mapped_to_correct_region(self):
+        from scraper.utils.region_mapper import get_region_from_province
+        assert get_region_from_province(Province.GOR) == "Friuli-Venezia Giulia"
+
+    def test_gor_not_sconosciuta(self):
+        loc = parse_location("Cormons (GOR)")
+        assert loc.region != "Sconosciuta"
+
+
 class TestParseLocation:
     """Tests for parse_location function."""
     

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -2,8 +2,108 @@
 Tests for parsing utilities.
 """
 import pytest
-from scraper.utils.parsers import parse_location, parse_distances
+from scraper.utils.parsers import extract_province_str, parse_location, parse_distances
 from scraper.models.provinces import Province
+
+
+class TestExtractProvinceStr:
+    """Unit test per la funzione pura extract_province_str."""
+
+    # --- Formato con parentesi ---
+
+    def test_parentheses_standard(self):
+        assert extract_province_str("Spinone al Lago (BG)") == ("Spinone al Lago", "BG")
+
+    def test_parentheses_single_word_city(self):
+        assert extract_province_str("Milano (MI)") == ("Milano", "MI")
+
+    def test_parentheses_multiword_city(self):
+        assert extract_province_str("San Giovanni Bianco (BG)") == ("San Giovanni Bianco", "BG")
+
+    def test_parentheses_city_with_brackets(self):
+        assert extract_province_str("Carvico [Tensostruttura] (BG)") == ("Carvico [Tensostruttura]", "BG")
+
+    def test_parentheses_lowercase_province_normalized(self):
+        city, prov = extract_province_str("Milano (mi)")
+        assert prov == "MI"
+        assert city == "Milano"
+
+    def test_parentheses_no_space_before(self):
+        city, prov = extract_province_str("Roma(RM)")
+        assert prov == "RM"
+        assert city == "Roma"
+
+    def test_parentheses_trailing_spaces(self):
+        city, prov = extract_province_str("  Bergamo (BG)  ")
+        assert prov == "BG"
+        assert city == "Bergamo"
+
+    def test_parentheses_only_province_no_city(self):
+        city, prov = extract_province_str("(BG)")
+        assert prov == "BG"
+        assert city == ""
+
+    # --- Formato senza parentesi (fallback posizionale) ---
+
+    def test_no_parens_standard(self):
+        assert extract_province_str("Varese VA") == ("Varese", "VA")
+
+    def test_no_parens_lowercase_normalized(self):
+        city, prov = extract_province_str("Brescia bs")
+        assert prov == "BS"
+        assert city == "Brescia"
+
+    def test_no_parens_multiword_city(self):
+        city, prov = extract_province_str("Lecco Abbadia Lariana LC")
+        assert prov == "LC"
+        assert city == "Lecco Abbadia Lariana"
+
+    def test_no_parens_extra_internal_spaces(self):
+        city, prov = extract_province_str("  Lecco   LC  ")
+        assert prov == "LC"
+        assert city == "Lecco"
+
+    # --- Nessuna provincia rilevabile ---
+
+    def test_single_word_no_province(self):
+        city, prov = extract_province_str("Bergamo")
+        assert prov is None
+        assert city == "Bergamo"
+
+    def test_empty_string(self):
+        city, prov = extract_province_str("")
+        assert prov is None
+        assert city == ""
+
+    def test_only_spaces(self):
+        city, prov = extract_province_str("   ")
+        assert prov is None
+        assert city == ""
+
+    # --- Provincia non valida (stringa presente ma non riconoscibile) ---
+
+    def test_invalid_province_code_returned_as_is(self):
+        """extract_province_str non valida l'enum: ritorna la sigla grezza."""
+        city, prov = extract_province_str("Como XX")
+        assert prov == "XX"
+        assert city == "Como"
+
+    # --- Parametrizzato su formati misti ---
+
+    @pytest.mark.parametrize("input_str,expected_city,expected_prov", [
+        ("Roma (RM)",          "Roma",          "RM"),
+        ("Torino (TO)",        "Torino",        "TO"),
+        ("Napoli (NA)",        "Napoli",        "NA"),
+        ("Palermo (PA)",       "Palermo",       "PA"),
+        ("Venezia (VE)",       "Venezia",       "VE"),
+        ("Venezia VE",         "Venezia",       "VE"),
+        ("Trento TN",          "Trento",        "TN"),
+        ("Bolzano (BZ)",       "Bolzano",       "BZ"),
+    ])
+    def test_various_formats(self, input_str, expected_city, expected_prov):
+        city, prov = extract_province_str(input_str)
+        assert city == expected_city
+        assert prov == expected_prov
 
 
 class TestParseLocation:


### PR DESCRIPTION
## Summary

- Refactored `parse_location` to use regex for explicit `(XX)` parenthesised format before falling back to positional last-token parsing
- Extracted pure function `extract_province_str()` for isolated, testable province detection
- Fixed `upsert_location` to update `region` if it changed (previously stale values like `"Sconosciuta"` were never corrected)
- Mapped `GOR` (non-standard FIASP code for Gorizia) to `"Friuli-Venezia Giulia"` instead of `"Sconosciuta"`
- Removed `ZA` from the province enum (no Italian province, never appears in scraped data)
- Added 27 new unit tests covering all the above changes

## Test plan
- [ ] `pytest tests/test_parsers.py` — all 52 tests pass
- [ ] Full suite `pytest tests/` — only pre-existing failures remain
- [ ] Scraper run completes without new errors