### PR TITLE
fix: strip punctuation noise from province candidate

### DIFF
--- a/scraper/utils/parsers.py
+++ b/scraper/utils/parsers.py
@@ -31,7 +31,8 @@ def extract_province_str(text: str) -> tuple[str, str | None]:
 
     parts = raw.split()
     if len(parts) >= 2:
-        return " ".join(parts[:-1]), parts[-1].strip("()").upper()
+        candidate = re.sub(r'[^A-Za-z]', '', parts[-1]).upper()
+        return " ".join(parts[:-1]), candidate or None
 
     return raw, None
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -88,6 +88,12 @@ class TestExtractProvinceStr:
         assert prov == "XX"
         assert city == "Como"
 
+    def test_trailing_punctuation_stripped(self):
+        """Punteggiatura finale rimossa dal candidato provincia (es. 'BG.' da FIASP)."""
+        city, prov = extract_province_str("Bergamo BG.")
+        assert prov == "BG"
+        assert city == "Bergamo"
+
     # --- Parametrizzato su formati misti ---
 
     @pytest.mark.parametrize("input_str,expected_city,expected_prov", [


### PR DESCRIPTION
## Summary

Province codes extracted via the positional fallback could carry trailing punctuation from source data (e.g. `BG.` from FIASP). The old `strip("()")` only removed parentheses; the new `re.sub(r'[^A-Za-z]', '', ...)` removes all non-letter characters before the enum lookup.

- `BG.` → `BG` ✓
- A candidate that reduces to an empty string is treated as `None`, falling through to the default province

Unresolvable codes (e.g. `LOD`, city-name words from CSI) are accepted as-is per product decision: events are kept even with a wrong province rather than being dropped.

## Test plan
- [ ] `pytest tests/test_parsers.py` — 53 tests pass
- [ ] New test `test_trailing_punctuation_stripped` covers the `BG.` case