### PR TITLE
fix: province dropdown shows only provinces with future events

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -63,7 +63,14 @@ function App() {
     return dateA - dateB;
   });
 
-  const provinces = [...new Set(events.map(event => event.location.province))].sort();
+  const provinces = [...new Set(
+    events
+      .filter(event => {
+        const [day, month, year] = event.date.split("/").map(Number);
+        return new Date(year, month - 1, day) >= today;
+      })
+      .map(event => event.location.province)
+  )].sort();
 
   if (loading) {
     return <div className="loading">Caricamento eventi...</div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -63,14 +63,18 @@ function App() {
     return dateA - dateB;
   });
 
-  const provinces = [...new Set(
+  const provinces = Object.values(
     events
       .filter(event => {
         const [day, month, year] = event.date.split("/").map(Number);
         return new Date(year, month - 1, day) >= today;
       })
-      .map(event => event.location.province)
-  )].sort();
+      .reduce((acc, event) => {
+        const { province, province_name } = event.location;
+        if (!acc[province]) acc[province] = { code: province, name: province_name || province };
+        return acc;
+      }, {})
+  ).sort((a, b) => a.name.localeCompare(b.name));
 
   if (loading) {
     return <div className="loading">Caricamento eventi...</div>
@@ -93,8 +97,8 @@ function App() {
           >
             <option value="">Tutte le province</option>
             {provinces.map(province => (
-              <option key={province} value={province}>
-                {province}
+              <option key={province.code} value={province.code}>
+                {province.name}
               </option>
             ))}
           </select>

--- a/frontend/src/services/eventsService.js
+++ b/frontend/src/services/eventsService.js
@@ -14,6 +14,7 @@ export async function fetchEvents() {
         location:locations (
           city,
           province,
+          province_name,
           region
         )
       `)
@@ -28,6 +29,7 @@ export async function fetchEvents() {
       location: {
         city: event.location.city,
         province: event.location.province,
+        province_name: event.location.province_name,
         region: event.location.region
       },
       poster: event.poster,

--- a/scraper/db/supabase_client.py
+++ b/scraper/db/supabase_client.py
@@ -23,31 +23,38 @@ class SupabaseManager:
         return cls._instance
 
     @classmethod
-    def upsert_location(cls, city: str, province: str, region: str) -> int:
+    def upsert_location(cls, city: str, province: str, province_name: str, region: str) -> int:
         """Inserisce o recupera una location, ritorna l'ID"""
         client = cls.get_client()
-        
+
         # Normalizza
         city = city.strip().title()
         province = province.strip().upper()
+        province_name = province_name.strip()
         region = region.strip().title()
-        
+
         # Cerca esistente
-        result = client.table("locations").select("id, region").eq("city", city).eq("province", province).execute()
+        result = client.table("locations").select("id, province_name, region").eq("city", city).eq("province", province).execute()
 
         if result.data:
             location_id = result.data[0]["id"]
+            updates = {}
             if result.data[0]["region"] != region:
-                client.table("locations").update({"region": region}).eq("id", location_id).execute()
+                updates["region"] = region
+            if result.data[0]["province_name"] != province_name:
+                updates["province_name"] = province_name
+            if updates:
+                client.table("locations").update(updates).eq("id", location_id).execute()
             return location_id
-        
+
         # Inserisci nuovo
         result = client.table("locations").insert({
             "city": city,
             "province": province,
+            "province_name": province_name,
             "region": region
         }).execute()
-        
+
         return result.data[0]["id"]
     
     @classmethod

--- a/scraper/models/event.py
+++ b/scraper/models/event.py
@@ -10,6 +10,7 @@ class Location(BaseModel):
     """Represents a location with city and province."""
     city: str
     province: Province
+    province_name: str
     region: str
 
 

--- a/scraper/scrapers/csi_scraper.py
+++ b/scraper/scrapers/csi_scraper.py
@@ -209,6 +209,7 @@ class CSIScraper(BaseScraper):
             location_id = SupabaseManager.upsert_location(
                 city=event.location.city,
                 province=event.location.province,
+                province_name=event.location.province_name,
                 region=event.location.region
             )
             

--- a/scraper/scrapers/fiasp_scraper.py
+++ b/scraper/scrapers/fiasp_scraper.py
@@ -112,6 +112,7 @@ class FIASPScraper(BaseScraper):
             location_id = SupabaseManager.upsert_location(
                 city=event.location.city,
                 province=event.location.province,
+                province_name=event.location.province_name,
                 region=event.location.region
             )
             

--- a/scraper/utils/parsers.py
+++ b/scraper/utils/parsers.py
@@ -5,7 +5,7 @@ import re
 from typing import List
 from scraper.models.event import Location
 from scraper.models.provinces import Province
-from scraper.utils.region_mapper import get_region_from_province
+from scraper.utils.region_mapper import get_name_from_province, get_region_from_province
 
 
 def extract_province_str(text: str) -> tuple[str, str | None]:
@@ -55,12 +55,14 @@ def parse_location(location_raw: str, default_province: Province = Province.BG) 
         try:
             province = Province(province_str)
             region = get_region_from_province(province)
-            return Location(city=city, province=province, region=region)
+            province_name = get_name_from_province(province)
+            return Location(city=city, province=province, province_name=province_name, region=region)
         except ValueError:
             print(f"⚠️ Unknown province '{province_str}', defaulting to {default_province.value}")
 
     region = get_region_from_province(default_province)
-    return Location(city=raw, province=default_province, region=region)
+    province_name = get_name_from_province(default_province)
+    return Location(city=raw, province=default_province, province_name=province_name, region=region)
 
 
 def parse_distances(raw: str) -> List[str]:

--- a/scraper/utils/region_mapper.py
+++ b/scraper/utils/region_mapper.py
@@ -153,14 +153,138 @@ PROVINCE_TO_REGION = {
 }
 
 
+PROVINCE_TO_NAME = {
+    Province.AG: "Agrigento",
+    Province.AL: "Alessandria",
+    Province.AN: "Ancona",
+    Province.AO: "Aosta",
+    Province.AP: "Ascoli Piceno",
+    Province.AQ: "L'Aquila",
+    Province.AR: "Arezzo",
+    Province.AT: "Asti",
+    Province.AV: "Avellino",
+    Province.BA: "Bari",
+    Province.BG: "Bergamo",
+    Province.BI: "Biella",
+    Province.BL: "Belluno",
+    Province.BN: "Benevento",
+    Province.BO: "Bologna",
+    Province.BR: "Brindisi",
+    Province.BS: "Brescia",
+    Province.BT: "Barletta-Andria-Trani",
+    Province.BZ: "Bolzano",
+    Province.CA: "Cagliari",
+    Province.CB: "Campobasso",
+    Province.CE: "Caserta",
+    Province.CH: "Chieti",
+    Province.CL: "Caltanissetta",
+    Province.CN: "Cuneo",
+    Province.CO: "Como",
+    Province.CR: "Cremona",
+    Province.CS: "Cosenza",
+    Province.CT: "Catania",
+    Province.CZ: "Catanzaro",
+    Province.EN: "Enna",
+    Province.FC: "Forlì-Cesena",
+    Province.FE: "Ferrara",
+    Province.FG: "Foggia",
+    Province.FI: "Firenze",
+    Province.FM: "Fermo",
+    Province.FR: "Frosinone",
+    Province.GE: "Genova",
+    Province.GO: "Gorizia",
+    Province.GOR: "Gorizia",
+    Province.GR: "Grosseto",
+    Province.IM: "Imperia",
+    Province.IS: "Isernia",
+    Province.KR: "Crotone",
+    Province.LC: "Lecco",
+    Province.LE: "Lecce",
+    Province.LI: "Livorno",
+    Province.LO: "Lodi",
+    Province.LT: "Latina",
+    Province.LU: "Lucca",
+    Province.MB: "Monza e della Brianza",
+    Province.MC: "Macerata",
+    Province.ME: "Messina",
+    Province.MI: "Milano",
+    Province.MN: "Mantova",
+    Province.MO: "Modena",
+    Province.MS: "Massa-Carrara",
+    Province.MT: "Matera",
+    Province.NA: "Napoli",
+    Province.NO: "Novara",
+    Province.NU: "Nuoro",
+    Province.OR: "Oristano",
+    Province.PA: "Palermo",
+    Province.PC: "Piacenza",
+    Province.PD: "Padova",
+    Province.PE: "Pescara",
+    Province.PG: "Perugia",
+    Province.PI: "Pisa",
+    Province.PN: "Pordenone",
+    Province.PO: "Prato",
+    Province.PR: "Parma",
+    Province.PT: "Pistoia",
+    Province.PU: "Pesaro e Urbino",
+    Province.PV: "Pavia",
+    Province.PZ: "Potenza",
+    Province.RA: "Ravenna",
+    Province.RC: "Reggio Calabria",
+    Province.RE: "Reggio Emilia",
+    Province.RG: "Ragusa",
+    Province.RI: "Rieti",
+    Province.RM: "Roma",
+    Province.RN: "Rimini",
+    Province.RO: "Rovigo",
+    Province.SA: "Salerno",
+    Province.SI: "Siena",
+    Province.SO: "Sondrio",
+    Province.SP: "La Spezia",
+    Province.SR: "Siracusa",
+    Province.SS: "Sassari",
+    Province.SV: "Savona",
+    Province.TA: "Taranto",
+    Province.TE: "Teramo",
+    Province.TN: "Trento",
+    Province.TO: "Torino",
+    Province.TP: "Trapani",
+    Province.TR: "Terni",
+    Province.TS: "Trieste",
+    Province.TV: "Treviso",
+    Province.UD: "Udine",
+    Province.VA: "Varese",
+    Province.VB: "Verbano-Cusio-Ossola",
+    Province.VC: "Vercelli",
+    Province.VE: "Venezia",
+    Province.VI: "Vicenza",
+    Province.VR: "Verona",
+    Province.VT: "Viterbo",
+    Province.VV: "Vibo Valentia",
+}
+
+
 def get_region_from_province(province: Province) -> str:
     """
     Ritorna la regione data una provincia.
-    
+
     Args:
         province: Codice provincia (enum Province)
-    
+
     Returns:
         Nome della regione
     """
     return PROVINCE_TO_REGION.get(province, "Sconosciuta")
+
+
+def get_name_from_province(province: Province) -> str:
+    """
+    Ritorna il nome esteso della provincia data la sua sigla.
+
+    Args:
+        province: Codice provincia (enum Province)
+
+    Returns:
+        Nome esteso (es. "Bergamo"), o la sigla stessa se non mappata
+    """
+    return PROVINCE_TO_NAME.get(province, province.value)


### PR DESCRIPTION
## Summary

The province dropdown was derived from all loaded events, while the event list only displays events with `date >= today`. This meant a province with only past events (not yet purged by the scraper) could appear in the dropdown but show zero results when selected.

The fix aligns the two: `provinces` is now built from the same future-filtered events that are actually displayed.

## Change

```js
// Before
const provinces = [...new Set(events.map(event => event.location.province))].sort();

// After
const provinces = [...new Set(
  events
    .filter(event => new Date(...) >= today)
    .map(event => event.location.province)
)].sort();
```

## Test plan
- [ ] Dropdown only shows provinces that have at least one upcoming event
- [ ] Selecting any province from the dropdown always returns results