### PR TITLE
Graphic tweaks: layout card, animazioni hover, fix iOS

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,6 +65,8 @@
 
 .province-filter {
   padding: 1rem 2rem;
+  color: var(--color-text-dark);
+  -webkit-text-fill-color: var(--color-text-dark);
   border: 4px solid var(--color-text-dark);
   border-radius: 0;
   background: white;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -71,7 +71,6 @@
   font-size: 1.5rem;
   font-weight: 900;
   cursor: pointer;
-  transition: all 0.2s ease;
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -84,8 +83,6 @@
 }
 
 .province-filter:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
 }
 
 .province-filter:focus {
@@ -256,7 +253,6 @@
   cursor: pointer;
   font-weight: 700;
   font-size: 1rem;
-  transition: all 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -266,8 +262,6 @@
 
 .poster-button:hover {
   background: var(--color-yellow);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
 /* ---- FOOTER ---- */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -176,8 +176,25 @@
   padding: 1.5rem 2rem;
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 2rem;
-  align-items: center;
+  grid-template-areas:
+    "title title"
+    "details actions";
+  column-gap: 2rem;
+  row-gap: 0.5rem;
+  align-items: start;
+}
+
+.event-title {
+  grid-area: title;
+}
+
+.event-details {
+  grid-area: details;
+}
+
+.event-actions {
+  grid-area: actions;
+  align-self: end;
 }
 
 /* ---- EVENT DIVIDER ---- */
@@ -185,12 +202,6 @@
   width: 100%;
   height: 5px;
   background: var(--color-cyan);
-}
-
-.event-info {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
 }
 
 .event-actions {
@@ -375,22 +386,8 @@
 
 /* ---- RESPONSIVE ---- */
 @media (max-width: 1024px) {
-  .event-content {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-  }
-
-  .event-actions {
-    align-items: flex-start;
-  }
-
   .event-source {
     text-align: left;
-  }
-
-  .poster-button {
-    width: auto;
-    align-self: flex-start;
   }
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -179,29 +179,27 @@ function EventCard({ event }) {
     <>
       <div className="event-card">
         <div className="event-content">
-          <div className="event-info">
-            <h3 className="event-title">{event.title}</h3>
-            
-            <div className="event-details">
-              <p className="event-location">
-                {event.location.city} ({event.location.province})
+          <h3 className="event-title">{event.title}</h3>
+
+          <div className="event-details">
+            <p className="event-location">
+              {event.location.city} ({event.location.province})
+            </p>
+
+            <p className="event-date">
+              {formatDate(event.date)}
+            </p>
+
+            {event.distances && event.distances.length > 0 && (
+              <p className="event-distances">
+                km: {event.distances.join(' - ')}
               </p>
-              
-              <p className="event-date">
-                {formatDate(event.date)}
-              </p>
-              
-              {event.distances && event.distances.length > 0 && (
-                <p className="event-distances">
-                  km: {event.distances.join(' - ')}
-                </p>
-              )}
-            </div>
+            )}
           </div>
 
           <div className="event-actions">
             {event.poster && (
-              <button 
+              <button
                 className="poster-button"
                 onClick={() => window.open(event.poster, '_blank')}
               >


### PR DESCRIPTION
## Summary
- Rimossi `transform`/`box-shadow`/`transition` da hover su filtro provincia e bottone poster
- Ristrutturato layout EventCard: titolo full-width, bottone affiancato a data/distanze e allineato in basso
- Fix testo blu su `<select>` in iOS Safari con `-webkit-text-fill-color`

## Test plan
- [ ] Verificare assenza animazioni hover su filtro e bottone poster
- [ ] Verificare layout card su desktop e mobile
- [ ] Verificare colore testo filtro su Safari iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)