### PR TITLE
security: valida immagini poster prima di passarle a img2pdf

### DIFF
--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -3,5 +3,4 @@ beautifulsoup4>=4.12.0
 pydantic>=2.0.0
 supabase>=2.0.0
 python-dotenv>=1.0.0
-img2pdf>=0.4.0
-``` 
+img2pdf>=0.5.1

--- a/scraper/scrapers/csi_scraper.py
+++ b/scraper/scrapers/csi_scraper.py
@@ -125,15 +125,30 @@ class CSIScraper(BaseScraper):
         if not imgs:
             return None
 
+        MAX_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MB per immagine
+
         image_bytes_list = []
         for img in imgs:
             src = img.get("src")
             if not src:
                 continue
-            url = f"{BASE_CSI_BERGAMO}{src}" if src.startswith("/") else src
+            if src.startswith("/"):
+                url = f"{BASE_CSI_BERGAMO}{src}"
+            elif src.startswith("https://"):
+                url = src
+            else:
+                print(f"⚠️ Skipped poster image with unsafe URL scheme: {src!r}")
+                continue
             try:
                 resp = requests.get(url, timeout=REQUEST_TIMEOUT)
                 resp.raise_for_status()
+                content_type = resp.headers.get("Content-Type", "")
+                if not content_type.startswith("image/"):
+                    print(f"⚠️ Skipped poster image with unexpected Content-Type {content_type!r}: {url}")
+                    continue
+                if len(resp.content) > MAX_IMAGE_BYTES:
+                    print(f"⚠️ Skipped poster image exceeding size limit ({len(resp.content)} bytes): {url}")
+                    continue
                 image_bytes_list.append(resp.content)
             except Exception as e:
                 print(f"⚠️ Failed to download poster image {url}: {e}")


### PR DESCRIPTION
## Summary

- Accetta solo URL `https://` per immagini con path assoluto — previene SSRF se il sito CSI venisse compromesso
- Verifica che il `Content-Type` della risposta sia `image/*` — evita che payload mascherati da immagini arrivino a `img2pdf`
- Limite di 10 MB per singola immagine — previene memory exhaustion
- Aggiorna pin `img2pdf` a `>=0.5.1` e rimuove riga spuria (`\`\`\``) in `requirements.txt`

## Test plan

- [ ] Verificare che lo scraper CSI continui a scaricare e caricare correttamente i poster validi
- [ ] Verificare che immagini con URL non-https vengano skippate con warning nel log
- [ ] Verificare che risposte con Content-Type non-image vengano ignorate

🤖 Generated with [Claude Code](https://claude.com/claude-code)