### PR TITLE
fix(a11y): risolve problemi critici di accessibilità

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="it">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg" type="image/svg+xml" />

--- a/frontend/src/components/EventCard/EventCard.css
+++ b/frontend/src/components/EventCard/EventCard.css
@@ -85,6 +85,11 @@
   background: var(--color-yellow);
 }
 
+.poster-button:focus {
+  outline: 3px solid var(--color-text-dark);
+  outline-offset: 3px;
+}
+
 @media (max-width: 768px) {
   .event-content {
     padding: 1.5rem 1rem;

--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -14,6 +14,13 @@
   transition: padding 0.6s cubic-bezier(0, 0, 0.2, 1);
 }
 
+.site-title {
+  margin: 0;
+  padding: 0;
+  line-height: 0;
+  font-size: 0;
+}
+
 .logo {
   max-height: 400px;
   max-width: 800px;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -8,7 +8,9 @@ export default function Header({ scrolled = false }: Props) {
   return (
     <header className={`header${scrolled ? ' header--scrolled' : ''}`}>
       <div className="header-content">
-        <img src={process.env.PUBLIC_URL + '/header.svg'} alt="Logo Tapasciate" className="logo" />
+        <h1 className="site-title">
+          <img src={process.env.PUBLIC_URL + '/header.svg'} alt="Tapasciate" className="logo" />
+        </h1>
       </div>
     </header>
   )

--- a/frontend/src/components/ProvinceFilter/ProvinceFilter.css
+++ b/frontend/src/components/ProvinceFilter/ProvinceFilter.css
@@ -35,7 +35,8 @@
 }
 
 .province-filter:focus {
-  outline: none;
+  outline: 3px solid var(--color-text-dark);
+  outline-offset: 3px;
   border-color: var(--color-text-dark);
 }
 

--- a/frontend/src/components/ProvinceFilter/ProvinceFilter.tsx
+++ b/frontend/src/components/ProvinceFilter/ProvinceFilter.tsx
@@ -19,6 +19,7 @@ export default function ProvinceFilter({ status, provinces, selectedProvince, on
             value={selectedProvince}
             onChange={(e) => onChange(e.target.value)}
             className="province-filter"
+            aria-label="Filtra per provincia"
           >
             <option value="">Tutte le province</option>
             {provinces.map(province => (


### PR DESCRIPTION
## Problemi risolti

| # | Problema | File | WCAG |
|---|----------|------|------|
| 1 | `lang="en"` su sito in italiano | `index.html` | 3.1.1 |
| 2 | Nessun `<h1>` nella pagina | `Header.tsx/css` | 1.3.1 |
| 3 | `<select>` senza label accessibile | `ProvinceFilter.tsx` | 1.3.1, 4.1.2 |
| 4 | Focus ring rimosso da `outline: none` | `ProvinceFilter.css`, `EventCard.css` | 2.4.7 |

## Dettagli

- **`lang="it"`**: i screen reader usano questo attributo per scegliere voce e pronuncia
- **`<h1>`**: il logo SVG è ora avvolto in un `<h1 class="site-title">` con reset CSS che non altera il layout visivo; `alt` aggiornato da "Logo Tapasciate" a "Tapasciate" (il prefisso "Logo" è ridondante nell'h1)
- **`aria-label`**: il select del filtro ora annuncia "Filtra per provincia" agli screen reader
- **Focus ring**: `outline: 3px solid` con `outline-offset: 3px` su select e poster-button, coerente con il design system esistente

## Test plan

- [ ] Navigare la pagina con solo tastiera: verificare che il focus sia visibile su select e pulsanti poster
- [ ] Testare con VoiceOver/NVDA: verificare che il select venga annunciato come "Filtra per provincia"
- [ ] Verificare che il logo rimanga invariato visivamente in stato normale e scrolled
- [ ] Verificare che la gerarchia heading sia h1 → h2 (date) → h3 (titoli eventi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)