### PR TITLE
fix(seo): meta description, OG tags, sitemap, JSON-LD e security headers

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,26 +6,24 @@
     <link rel="alternate icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
+    <meta name="description" content="Tapasciate.it — il calendario delle manifestazioni podistiche non competitive in Italia. Trova le tapasciate nella tua provincia." />
+    <link rel="canonical" href="https://tapasciate.it/" />
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>Tapasciate.it</title>
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tapasciate.it/" />
+    <meta property="og:title" content="Tapasciate.it — Manifestazioni podistiche non competitive in Italia" />
+    <meta property="og:description" content="Il calendario delle tapasciate in Italia: manifestazioni podistiche non competitive. Cerca per provincia e data." />
+    <meta property="og:locale" content="it_IT" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Tapasciate.it — Manifestazioni podistiche non competitive in Italia" />
+    <meta name="twitter:description" content="Il calendario delle tapasciate in Italia: manifestazioni podistiche non competitive. Cerca per provincia e data." />
+
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>Tapasciate.it — Manifestazioni podistiche non competitive in Italia</title>
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="it">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg" type="image/svg+xml" />

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,6 +24,24 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>Tapasciate.it — Manifestazioni podistiche non competitive in Italia</title>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Tapasciate.it",
+      "url": "https://tapasciate.it/",
+      "description": "Il calendario delle tapasciate in Italia: manifestazioni podistiche non competitive. Cerca per provincia e data.",
+      "inLanguage": "it",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Tapasciate.it",
+        "url": "https://tapasciate.it/"
+      }
+    }
+    </script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,8 @@
 {
   "short_name": "Tapasciate.it",
-  "name": "Create React App Sample",
+  "name": "Tapasciate.it — Manifestazioni podistiche non competitive",
+  "description": "Il calendario delle tapasciate in Italia: manifestazioni podistiche non competitive. Cerca per provincia e data.",
+  "lang": "it",
   "icons": [
     {
       "src": "favicon.ico",

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+Sitemap: https://tapasciate.it/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://tapasciate.it/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://tapasciate.it/info.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://tapasciate.it/privacy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>

--- a/frontend/src/components/EventCard/EventCard.css
+++ b/frontend/src/components/EventCard/EventCard.css
@@ -85,6 +85,11 @@
   background: var(--color-yellow);
 }
 
+.poster-button:focus {
+  outline: 3px solid var(--color-text-dark);
+  outline-offset: 3px;
+}
+
 @media (max-width: 768px) {
   .event-content {
     padding: 1.5rem 1rem;

--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -14,6 +14,13 @@
   transition: padding 0.6s cubic-bezier(0, 0, 0.2, 1);
 }
 
+.site-title {
+  margin: 0;
+  padding: 0;
+  line-height: 0;
+  font-size: 0;
+}
+
 .logo {
   max-height: 400px;
   max-width: 800px;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -8,7 +8,9 @@ export default function Header({ scrolled = false }: Props) {
   return (
     <header className={`header${scrolled ? ' header--scrolled' : ''}`}>
       <div className="header-content">
-        <img src={process.env.PUBLIC_URL + '/header.svg'} alt="Logo Tapasciate" className="logo" />
+        <h1 className="site-title">
+          <img src={process.env.PUBLIC_URL + '/header.svg'} alt="Tapasciate" className="logo" />
+        </h1>
       </div>
     </header>
   )

--- a/frontend/src/components/ProvinceFilter/ProvinceFilter.css
+++ b/frontend/src/components/ProvinceFilter/ProvinceFilter.css
@@ -35,7 +35,8 @@
 }
 
 .province-filter:focus {
-  outline: none;
+  outline: 3px solid var(--color-text-dark);
+  outline-offset: 3px;
   border-color: var(--color-text-dark);
 }
 

--- a/frontend/src/components/ProvinceFilter/ProvinceFilter.tsx
+++ b/frontend/src/components/ProvinceFilter/ProvinceFilter.tsx
@@ -19,6 +19,7 @@ export default function ProvinceFilter({ status, provinces, selectedProvince, on
             value={selectedProvince}
             onChange={(e) => onChange(e.target.value)}
             className="province-filter"
+            aria-label="Filtra per provincia"
           >
             <option value="">Tutte le province</option>
             {provinces.map(province => (

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,22 @@
   command = "npm run build"
   publish = "build"
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+
 [[redirects]]
   from   = "/privacy"
   to     = "/privacy.html"
+  status = 200
+
+[[redirects]]
+  from   = "/info"
+  to     = "/info.html"
   status = 200
 
 [[redirects]]


### PR DESCRIPTION
## Summary

- Sostituisce la meta description di default CRA e aggiorna il titolo della pagina con testo corretto su tapasciate e podismo non competitivo
- Aggiunge tag Open Graph, Twitter Card e link canonical
- Crea `sitemap.xml` con homepage, `/info.html` e `/privacy.html`
- Aggiunge direttiva `Sitemap:` in `robots.txt`
- Aggiunge JSON-LD structured data (`WebSite` + `Organization`) per i rich snippet
- Corregge `manifest.json` (name, description, lang)
- Aggiunge security headers su Netlify (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`)
- Aggiunge redirect `/info` → `/info.html` (mancava)

## Test plan

- [ ] Verificare su [Rich Results Test](https://search.google.com/test/rich-results) che il JSON-LD sia valido
- [ ] Verificare la preview OG su [opengraph.xyz](https://www.opengraph.xyz/) con l'URL di produzione
- [ ] Verificare che `https://tapasciate.it/sitemap.xml` sia raggiungibile dopo il deploy
- [ ] Verificare gli header di sicurezza con `curl -I https://tapasciate.it`

🤖 Generated with [Claude Code](https://claude.com/claude-code)