### PR TITLE
feat: aggiungi test unitari, di integrazione e E2E

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ cd frontend
 npm install          # Install dependencies
 npm start            # Dev server at http://localhost:3000
 npm run build        # Production build → frontend/build/
-npm test             # Run tests (Jest + React Testing Library)
+npm test             # Run unit/integration tests (Jest + React Testing Library)
+npm run test:e2e     # Run E2E tests (Playwright, richiede dev server o lo avvia in automatico)
 ```
 
 ### Scraper (Python)
@@ -74,7 +75,8 @@ App
 | Backend | Python 3.11, BeautifulSoup4, Pydantic |
 | Database | Supabase (PostgreSQL) |
 | Hosting | Netlify (frontend), GitHub Actions (scraper) |
-| Testing | Jest + React Testing Library |
+| Unit/Integration Testing | Jest + React Testing Library |
+| E2E Testing | Playwright (Chromium) |
 | Analytics | Google Tag Manager (GTM-W694RKFF) |
 
 ## Convenzioni
@@ -83,4 +85,5 @@ App
 - **Componenti**: ogni componente ha la sua cartella in `components/` con file `.tsx` e `.css` dedicati
 - **Niente routing library**: l'app è single-page senza React Router. Non introdurlo senza discussione
 - **CSS**: nessun CSS-in-JS, nessun framework UI. Solo CSS modules o file `.css` plain
-- **Test**: tutti i file relativi ai test (setup e `*.test.ts/tsx`) si trovano in `frontend/src/test/`
+- **Test unitari/integrazione**: file `*.test.ts/tsx` in `frontend/src/test/` (Jest + RTL)
+- **Test E2E**: file `*.spec.ts` in `frontend/tests/` (Playwright); le chiamate Supabase vengono intercettate con mock, nessun backend necessario

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**tapasciate.it** is a website listing orienteering races in Italy. It has two independent components:
-- **Frontend**: React SPA displaying events fetched from Supabase
+**tapasciate.it** is a website listing non-competitive walking races (tapasciate) in Italy. It has two independent components:
+- **Frontend**: React SPA (TypeScript) displaying events fetched from Supabase
 - **Scraper**: Python backend that scrapes race data from external sources and saves it to Supabase
 
 ## Commands
@@ -16,7 +16,7 @@ cd frontend
 npm install          # Install dependencies
 npm start            # Dev server at http://localhost:3000
 npm run build        # Production build → frontend/build/
-npm test             # Run tests
+npm test             # Run tests (Jest + React Testing Library)
 ```
 
 ### Scraper (Python)
@@ -35,30 +35,52 @@ pytest tests/        # Run tests
 3. Frontend reads events from Supabase and displays them filtered by province
 
 ### Frontend (`frontend/src/`)
-- **Single component app**: `App.js` handles all state, filtering, and rendering — no routing library
-- **`eventsService.js`**: Only data layer — fetches events from Supabase with location JOIN, converts dates from `YYYY-MM-DD` to `DD/MM/YYYY`
-- **`supabaseClient.js`**: Supabase client instance (URL and anon key are public/safe to commit)
-- Netlify handles deployment; `netlify.toml` configures build and SPA catch-all redirect
+
+**Component tree:**
+```
+App
+├── Header          — logo e titolo; aggiunge classe CSS quando la pagina è scrollata
+├── ProvinceFilter  — dropdown/pill per filtrare per provincia; disabilitato durante il caricamento
+├── EventList       — lista eventi raggruppati per data
+└── Footer
+```
+
+**Hooks e servizi:**
+- **`hooks/useEvents.ts`**: gestisce tutto lo stato — fetching, filtraggio per provincia, raggruppamento per data. Espone: `status`, `groupedEvents`, `sortedDates`, `provinces`, `selectedProvince`, `setProvince`
+- **`eventsService.ts`**: unico layer dati — chiama Supabase con JOIN su `locations`, mappa i campi al tipo `Event`
+- **`supabaseClient.ts`**: istanza Supabase (URL e anon key sono pubbliche, ok commitarle)
+- **`types/`**: tipi TypeScript condivisi (incluso `Event`)
+
+**`status`** è un discriminated union con almeno tre stati: `loading`, `success`, `error`.
 
 ### Scraper (`scraper/`)
-- `BaseScraper` abstract class in `scrapers/base.py` — all scrapers extend this
-- Each scraper returns `list[Event]` (Pydantic model from `models/event.py`)
-- `db/supabase_client.py` handles upsert logic using the event URL as unique key
-- `models/provinces.py` and `utils/region_mapper.py` normalize location data
+- `BaseScraper` abstract class in `scrapers/base.py` — tutti gli scraper la estendono
+- Ogni scraper restituisce `list[Event]` (Pydantic model da `models/event.py`)
+- `db/supabase_client.py` gestisce la logica di upsert usando l'URL dell'evento come chiave univoca
+- `models/provinces.py` e `utils/region_mapper.py` normalizzano i dati di localizzazione
 
 ### Database Schema (Supabase/PostgreSQL)
-- `locations`: id, city, province, region, created_at
+- `locations`: id, city, province, province_name, region, created_at
 - `events`: id, name, date, location_id, organizer, url, poster, distances, created_at, updated_at
 
 ### Deployment
-- **Frontend**: Netlify, auto-deploys from `main` branch (`base = "frontend"`)
-- **Scraper**: GitHub Actions (`.github/workflows/scraper.yml`), uses `SUPABASE_URL` and `SUPABASE_KEY` secrets
+- **Frontend**: Netlify, auto-deploy dal branch `main` (`base = "frontend"`)
+- **Scraper**: GitHub Actions (`.github/workflows/scraper.yml`), usa i secret `SUPABASE_URL` e `SUPABASE_KEY`
 
 ## Tech Stack
 | Layer | Technology |
 |-------|-----------|
-| Frontend | React 19, CSS3, Create React App |
+| Frontend | React 19, TypeScript, CSS3, Create React App |
 | Backend | Python 3.11, BeautifulSoup4, Pydantic |
 | Database | Supabase (PostgreSQL) |
 | Hosting | Netlify (frontend), GitHub Actions (scraper) |
+| Testing | Jest + React Testing Library |
 | Analytics | Google Tag Manager (GTM-W694RKFF) |
+
+## Convenzioni
+
+- **TypeScript**: tutto il frontend è in TypeScript. Non aggiungere file `.js` in `frontend/src/`
+- **Componenti**: ogni componente ha la sua cartella in `components/` con file `.tsx` e `.css` dedicati
+- **Niente routing library**: l'app è single-page senza React Router. Non introdurlo senza discussione
+- **CSS**: nessun CSS-in-JS, nessun framework UI. Solo CSS modules o file `.css` plain
+- **Test**: tutti i file relativi ai test (setup e `*.test.ts/tsx`) si trovano in `frontend/src/test/`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,10 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.93.3",
-        "@testing-library/dom": "^10.4.1",
-        "@testing-library/jest-dom": "^6.8.0",
-        "@testing-library/react": "^16.3.0",
-        "@testing-library/user-event": "^13.5.0",
         "@types/node": "^22.19.15",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -21,12 +17,21 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.59.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.8.0",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^13.5.0",
+        "@types/jest": "^30.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -2684,6 +2689,16 @@
         }
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.5.1.tgz",
@@ -2697,6 +2712,19 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
@@ -2716,6 +2744,16 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.5.1.tgz",
@@ -2728,6 +2766,30 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -3030,6 +3092,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -3533,6 +3611,7 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -3552,6 +3631,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -3561,6 +3641,7 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
       "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
@@ -3580,12 +3661,14 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
       "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -3613,6 +3696,7 @@
       "version": "13.5.0",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
       "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -3647,6 +3731,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -3843,6 +3928,234 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -6322,6 +6635,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cssdb": {
@@ -6690,6 +7004,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6813,6 +7128,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-converter": {
@@ -9352,6 +9668,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11360,6 +11677,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -11535,6 +11853,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -12321,6 +12640,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -14180,6 +14546,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -15660,6 +16027,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "dependencies": {
     "@supabase/supabase-js": "^2.93.3",
-    "@testing-library/dom": "^10.4.1",
-    "@testing-library/jest-dom": "^6.8.0",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^13.5.0",
     "@types/node": "^22.19.15",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -16,6 +12,12 @@
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^13.5.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,15 +14,18 @@
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^13.5.0"
+    "@testing-library/user-event": "^13.5.0",
+    "@types/jest": "^30.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:e2e": "playwright test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/frontend/src/test/EventCard.test.tsx
+++ b/frontend/src/test/EventCard.test.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import EventCard from '../components/EventCard/EventCard'
+import type { Event } from '../types'
+
+const baseEvent: Event = {
+  title: 'Tapasciata dei Colli',
+  date: '2026-06-15',
+  location: { city: 'Bergamo', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' },
+  poster: null,
+  source: null,
+  distances: [],
+}
+
+describe('EventCard', () => {
+  it('mostra il titolo dell\'evento', () => {
+    render(<EventCard event={baseEvent} />)
+    expect(screen.getByText('Tapasciata dei Colli')).toBeInTheDocument()
+  })
+
+  it('mostra città e provincia', () => {
+    render(<EventCard event={baseEvent} />)
+    expect(screen.getByText('Bergamo (BG)')).toBeInTheDocument()
+  })
+
+  it('non mostra il pulsante poster se poster è null', () => {
+    render(<EventCard event={baseEvent} />)
+    expect(screen.queryByRole('button', { name: /poster/i })).not.toBeInTheDocument()
+  })
+
+  it('mostra il pulsante poster se poster è fornito', () => {
+    const event = { ...baseEvent, poster: 'https://example.com/poster.pdf' }
+    render(<EventCard event={event} />)
+    expect(screen.getByRole('button', { name: /poster/i })).toBeInTheDocument()
+  })
+
+  it('apre l\'url del poster in una nuova tab al click', () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+    const event = { ...baseEvent, poster: 'https://example.com/poster.pdf' }
+    render(<EventCard event={event} />)
+    fireEvent.click(screen.getByRole('button', { name: /poster/i }))
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/poster.pdf', '_blank')
+    openSpy.mockRestore()
+  })
+
+  it('mostra le distanze quando presenti', () => {
+    const event = { ...baseEvent, distances: ['10', '21'] }
+    render(<EventCard event={event} />)
+    expect(screen.getByText('km: 10 - 21')).toBeInTheDocument()
+  })
+
+  it('non mostra la sezione distanze se l\'array è vuoto', () => {
+    render(<EventCard event={baseEvent} />)
+    expect(screen.queryByText(/^km:/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/EventList.test.tsx
+++ b/frontend/src/test/EventList.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import EventList from '../components/EventList/EventList'
+import type { Event } from '../types'
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    title: 'Test Event',
+    date: '2026-06-15',
+    location: { city: 'Bergamo', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' },
+    poster: null,
+    source: null,
+    distances: [],
+    ...overrides,
+  }
+}
+
+describe('EventList', () => {
+  it('mostra gli skeleton durante il caricamento', () => {
+    render(<EventList status="loading" sortedDates={[]} groupedEvents={{}} />)
+    expect(document.querySelector('.skeleton')).toBeInTheDocument()
+  })
+
+  it('non mostra la lista eventi durante il caricamento', () => {
+    render(<EventList status="loading" sortedDates={[]} groupedEvents={{}} />)
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument()
+  })
+
+  it('mostra il messaggio di errore quando status è error', () => {
+    render(<EventList status="error" sortedDates={[]} groupedEvents={{}} />)
+    expect(screen.getByText(/Errore nel caricamento degli eventi/)).toBeInTheDocument()
+  })
+
+  it('mostra il messaggio di stato vuoto quando non ci sono eventi', () => {
+    render(<EventList status="success" sortedDates={[]} groupedEvents={{}} />)
+    expect(screen.getByText(/Nessun evento trovato per questa provincia/)).toBeInTheDocument()
+  })
+
+  it('mostra gli eventi raggruppati per data', () => {
+    const groupedEvents = { '2026-06-15': [makeEvent()] }
+    render(
+      <EventList status="success" sortedDates={['2026-06-15']} groupedEvents={groupedEvents} />
+    )
+    expect(screen.getByText('Test Event')).toBeInTheDocument()
+  })
+
+  it('mostra il conteggio degli eventi per data', () => {
+    const groupedEvents = {
+      '2026-06-15': [makeEvent(), makeEvent({ title: 'Secondo Evento' })],
+    }
+    render(
+      <EventList status="success" sortedDates={['2026-06-15']} groupedEvents={groupedEvents} />
+    )
+    expect(screen.getByText(/2 tapasciate/)).toBeInTheDocument()
+  })
+
+  it('mostra più sezioni data', () => {
+    const groupedEvents = {
+      '2026-06-15': [makeEvent()],
+      '2026-07-01': [makeEvent({ title: 'Evento di Luglio' })],
+    }
+    render(
+      <EventList
+        status="success"
+        sortedDates={['2026-06-15', '2026-07-01']}
+        groupedEvents={groupedEvents}
+      />
+    )
+    expect(screen.getByText('Test Event')).toBeInTheDocument()
+    expect(screen.getByText('Evento di Luglio')).toBeInTheDocument()
+  })
+
+  it('mostra l\'intestazione della data in italiano', () => {
+    const groupedEvents = { '2026-04-01': [makeEvent()] }
+    render(
+      <EventList status="success" sortedDates={['2026-04-01']} groupedEvents={groupedEvents} />
+    )
+    expect(screen.getByText('Mercoledì 1 Aprile')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/ProvinceFilter.test.tsx
+++ b/frontend/src/test/ProvinceFilter.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ProvinceFilter from '../components/ProvinceFilter/ProvinceFilter'
+import type { Province } from '../types'
+
+const provinces: Province[] = [
+  { code: 'BG', name: 'Bergamo' },
+  { code: 'MI', name: 'Milano' },
+]
+
+describe('ProvinceFilter', () => {
+  it('mostra lo skeleton durante il caricamento', () => {
+    render(
+      <ProvinceFilter status="loading" provinces={[]} selectedProvince="" onChange={() => {}} />
+    )
+    expect(document.querySelector('.skeleton')).toBeInTheDocument()
+  })
+
+  it('non mostra il select durante il caricamento', () => {
+    render(
+      <ProvinceFilter status="loading" provinces={[]} selectedProvince="" onChange={() => {}} />
+    )
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+
+  it('mostra il select con le province quando non è in loading', () => {
+    render(
+      <ProvinceFilter status="success" provinces={provinces} selectedProvince="" onChange={() => {}} />
+    )
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+    expect(screen.getByText('Bergamo')).toBeInTheDocument()
+    expect(screen.getByText('Milano')).toBeInTheDocument()
+  })
+
+  it('la prima opzione è "Tutte le province"', () => {
+    render(
+      <ProvinceFilter status="success" provinces={provinces} selectedProvince="" onChange={() => {}} />
+    )
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveTextContent('Tutte le province')
+  })
+
+  it('chiama onChange con il codice provincia alla selezione', () => {
+    const onChange = jest.fn()
+    render(
+      <ProvinceFilter status="success" provinces={provinces} selectedProvince="" onChange={onChange} />
+    )
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'BG' } })
+    expect(onChange).toHaveBeenCalledWith('BG')
+  })
+
+  it('riflette la provincia selezionata nel valore del select', () => {
+    render(
+      <ProvinceFilter status="success" provinces={provinces} selectedProvince="MI" onChange={() => {}} />
+    )
+    expect(screen.getByRole('combobox')).toHaveValue('MI')
+  })
+
+  it('mostra il numero corretto di opzioni (province + tutte)', () => {
+    render(
+      <ProvinceFilter status="success" provinces={provinces} selectedProvince="" onChange={() => {}} />
+    )
+    expect(screen.getAllByRole('option')).toHaveLength(provinces.length + 1)
+  })
+})

--- a/frontend/src/test/formatDate.test.ts
+++ b/frontend/src/test/formatDate.test.ts
@@ -1,0 +1,23 @@
+import { formatDate } from '../utils/formatDate'
+
+describe('formatDate', () => {
+  it('formatta correttamente un mercoledì', () => {
+    expect(formatDate('2026-04-01')).toBe('Mercoledì 1 Aprile')
+  })
+
+  it('formatta correttamente una domenica', () => {
+    expect(formatDate('2026-04-05')).toBe('Domenica 5 Aprile')
+  })
+
+  it('formatta correttamente gennaio', () => {
+    expect(formatDate('2026-01-01')).toBe('Giovedì 1 Gennaio')
+  })
+
+  it('formatta correttamente dicembre', () => {
+    expect(formatDate('2026-12-25')).toBe('Venerdì 25 Dicembre')
+  })
+
+  it('gestisce correttamente giorni con zero iniziale nella stringa', () => {
+    expect(formatDate('2026-03-08')).toBe('Domenica 8 Marzo')
+  })
+})

--- a/frontend/src/test/useEvents.test.ts
+++ b/frontend/src/test/useEvents.test.ts
@@ -1,0 +1,121 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { act } from 'react'
+import { useEvents } from '../hooks/useEvents'
+import { fetchEvents } from '../services/eventsService'
+import type { Event } from '../types'
+
+jest.mock('../services/eventsService')
+const mockFetchEvents = fetchEvents as jest.MockedFunction<typeof fetchEvents>
+
+const FUTURE_DATE = '2030-06-15'
+const PAST_DATE = '2020-01-01'
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    title: 'Test Event',
+    date: FUTURE_DATE,
+    location: { city: 'Bergamo', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' },
+    poster: null,
+    source: null,
+    distances: [],
+    ...overrides,
+  }
+}
+
+describe('useEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('parte in stato loading', () => {
+    mockFetchEvents.mockImplementation(() => new Promise(() => {}))
+    const { result } = renderHook(() => useEvents())
+    expect(result.current.status).toBe('loading')
+  })
+
+  it('passa a success dopo il fetch', async () => {
+    mockFetchEvents.mockResolvedValue([makeEvent()])
+    const { result } = renderHook(() => useEvents())
+    await waitFor(() => expect(result.current.status).toBe('success'))
+  })
+
+  it('passa a error se il fetch fallisce', async () => {
+    mockFetchEvents.mockRejectedValue(new Error('Network error'))
+    const { result } = renderHook(() => useEvents())
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error).toBe('Network error')
+  })
+
+  it('esclude gli eventi passati da groupedEvents', async () => {
+    mockFetchEvents.mockResolvedValue([
+      makeEvent({ date: PAST_DATE }),
+      makeEvent({ date: FUTURE_DATE }),
+    ])
+    const { result } = renderHook(() => useEvents())
+    await waitFor(() => expect(result.current.status).toBe('success'))
+    expect(result.current.sortedDates).not.toContain(PAST_DATE)
+    expect(result.current.sortedDates).toContain(FUTURE_DATE)
+  })
+
+  it('filtra gli eventi per provincia selezionata', async () => {
+    mockFetchEvents.mockResolvedValue([
+      makeEvent({ location: { city: 'Bergamo', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' } }),
+      makeEvent({ location: { city: 'Milano', province: 'MI', province_name: 'Milano', region: 'Lombardia' } }),
+    ])
+    const { result } = renderHook(() => useEvents())
+    await waitFor(() => expect(result.current.status).toBe('success'))
+
+    act(() => result.current.setProvince('BG'))
+
+    const events = Object.values(result.current.groupedEvents).flat()
+    expect(events.every(e => e.location.province === 'BG')).toBe(true)
+  })
+
+  it('mostra tutti gli eventi se nessuna provincia è selezionata', async () => {
+    mockFetchEvents.mockResolvedValue([
+      makeEvent({ location: { city: 'Bergamo', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' } }),
+      makeEvent({ location: { city: 'Milano', province: 'MI', province_name: 'Milano', region: 'Lombardia' } }),
+    ])
+    const { result } = renderHook(() => useEvents())
+    await waitFor(() => expect(result.current.status).toBe('success'))
+
+    const events = Object.values(result.current.groupedEvents).flat()
+    expect(events).toHaveLength(2)
+  })
+
+  it('calcola le province solo dagli eventi futuri', async () => {
+    mockFetchEvents.mockResolvedValue([
+      makeEvent({ date: FUTURE_DATE, location: { city: 'Bergamo', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' } }),
+      makeEvent({ date: PAST_DATE, location: { city: 'Roma', province: 'RM', province_name: 'Roma', region: 'Lazio' } }),
+    ])
+    const { result } = renderHook(() => useEvents())
+    await waitFor(() => expect(result.current.status).toBe('success'))
+
+    const codes = result.current.provinces.map(p => p.code)
+    expect(codes).toContain('BG')
+    expect(codes).not.toContain('RM')
+  })
+
+  it('ordina le province alfabeticamente per nome', async () => {
+    mockFetchEvents.mockResolvedValue([
+      makeEvent({ location: { city: 'Torino', province: 'TO', province_name: 'Torino', region: 'Piemonte' } }),
+      makeEvent({ location: { city: 'Bergamo', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' } }),
+    ])
+    const { result } = renderHook(() => useEvents())
+    await waitFor(() => expect(result.current.status).toBe('success'))
+
+    const names = result.current.provinces.map(p => p.name)
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)))
+  })
+
+  it('deduplica le province con più eventi nella stessa provincia', async () => {
+    mockFetchEvents.mockResolvedValue([
+      makeEvent({ title: 'Evento 1', location: { city: 'Bergamo', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' } }),
+      makeEvent({ title: 'Evento 2', location: { city: 'Dalmine', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' } }),
+    ])
+    const { result } = renderHook(() => useEvents())
+    await waitFor(() => expect(result.current.status).toBe('success'))
+
+    expect(result.current.provinces.filter(p => p.code === 'BG')).toHaveLength(1)
+  })
+})

--- a/frontend/tests/ui.spec.ts
+++ b/frontend/tests/ui.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// --- Mock data ---
+
+const mockEvents = [
+  {
+    id: 1,
+    name: 'Tapasciata dei Colli',
+    date: '2030-06-15',
+    location: { city: 'Bergamo', province: 'BG', province_name: 'Bergamo', region: 'Lombardia' },
+    poster: 'https://example.com/poster.pdf',
+    organizer: 'CóR',
+    distances: ['10', '21'],
+    url: 'https://example.com/1',
+    location_id: 1,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'Tapasciata del Lago',
+    date: '2030-07-20',
+    location: { city: 'Milano', province: 'MI', province_name: 'Milano', region: 'Lombardia' },
+    poster: null,
+    organizer: 'NuovaDot',
+    distances: [],
+    url: 'https://example.com/2',
+    location_id: 2,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+async function mockSupabase(page: Page, data: typeof mockEvents | []) {
+  await page.route('**/rest/v1/events**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(data),
+    })
+  )
+}
+
+// --- Tests ---
+
+test.describe('Caricamento', () => {
+  test('mostra gli skeleton durante il fetch', async ({ page }) => {
+    await page.route('**/rest/v1/events**', async route => {
+      await new Promise(resolve => setTimeout(resolve, 1500))
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockEvents) })
+    })
+    await page.goto('/')
+    await expect(page.locator('.skeleton').first()).toBeVisible()
+  })
+
+  test('mostra gli eventi dopo il caricamento', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    await expect(page.getByText('Tapasciata dei Colli')).toBeVisible()
+    await expect(page.getByText('Tapasciata del Lago')).toBeVisible()
+  })
+
+  test('mostra il messaggio di errore se il fetch fallisce', async ({ page }) => {
+    await page.route('**/rest/v1/events**', route => route.abort('failed'))
+    await page.goto('/')
+    await expect(page.getByText(/Errore nel caricamento degli eventi/)).toBeVisible()
+  })
+
+  test('mostra lo stato vuoto se non ci sono eventi', async ({ page }) => {
+    await mockSupabase(page, [])
+    await page.goto('/')
+    await expect(page.getByText(/Nessun evento trovato per questa provincia/)).toBeVisible()
+  })
+})
+
+test.describe('Filtro province', () => {
+  test('mostra le province disponibili nel dropdown', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    const select = page.locator('.province-filter')
+    await expect(select).toBeVisible()
+    await expect(select.locator('option[value="BG"]')).toHaveText('Bergamo')
+    await expect(select.locator('option[value="MI"]')).toHaveText('Milano')
+  })
+
+  test('la prima opzione è "Tutte le province"', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    const firstOption = page.locator('.province-filter option').first()
+    await expect(firstOption).toHaveText('Tutte le province')
+  })
+
+  test('filtrare per provincia mostra solo gli eventi di quella provincia', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    await page.waitForSelector('.province-filter')
+    await page.selectOption('.province-filter', 'BG')
+    await expect(page.getByText('Tapasciata dei Colli')).toBeVisible()
+    await expect(page.getByText('Tapasciata del Lago')).not.toBeVisible()
+  })
+
+  test('tornare a "Tutte le province" mostra di nuovo tutti gli eventi', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    await page.waitForSelector('.province-filter')
+    await page.selectOption('.province-filter', 'BG')
+    await page.selectOption('.province-filter', '')
+    await expect(page.getByText('Tapasciata dei Colli')).toBeVisible()
+    await expect(page.getByText('Tapasciata del Lago')).toBeVisible()
+  })
+})
+
+test.describe('Scheda evento', () => {
+  test('mostra le distanze dell\'evento', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    await expect(page.getByText('km: 10 - 21')).toBeVisible()
+  })
+
+  test('mostra il pulsante poster se presente', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    await expect(page.getByRole('button', { name: /poster/i })).toBeVisible()
+  })
+
+  test('non mostra il pulsante poster se assente', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    // Solo l'evento con MI non ha poster: dopo aver filtrato per MI non deve esserci il bottone
+    await page.waitForSelector('.province-filter')
+    await page.selectOption('.province-filter', 'MI')
+    await expect(page.getByRole('button', { name: /poster/i })).not.toBeVisible()
+  })
+})
+
+test.describe('Header', () => {
+  test('l\'header non ha la classe scrolled all\'avvio', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    await expect(page.locator('header')).not.toHaveClass(/header--scrolled/)
+  })
+
+  test('l\'header riceve la classe scrolled dopo lo scroll', async ({ page }) => {
+    await mockSupabase(page, mockEvents)
+    await page.goto('/')
+    await page.waitForSelector('.event-card')
+    // Rende la pagina abbastanza alta da poter scrollare, poi scrolla
+    await page.evaluate(() => {
+      document.documentElement.style.minHeight = '3000px'
+      window.scrollBy(0, 300)
+    })
+    await expect(page.locator('header')).toHaveClass(/header--scrolled/)
+  })
+})


### PR DESCRIPTION
## Summary

- Aggiunge 36 test unitari/integrazione con Jest + React Testing Library in `frontend/src/test/`
- Aggiunge 13 test E2E con Playwright in `frontend/tests/` (mock Supabase, nessun backend necessario)
- Sposta le testing library da `dependencies` a `devDependencies`
- Rimuove riferimenti a Playwright non installato dal CLAUDE.md precedente
- Corregge la descrizione del progetto (tapasciate, non orienteering)

## Test coperti

**Jest + RTL (`npm test`)**
| File | Cosa testa |
|------|-----------|
| `formatDate.test.ts` | Formattazione date in italiano |
| `useEvents.test.ts` | Hook: loading/success/error, filtraggio, province, deduplicazione |
| `EventCard.test.tsx` | Rendering dati, poster condizionale, distanze |
| `EventList.test.tsx` | Skeleton, errore, stato vuoto, raggruppamento, conteggio |
| `ProvinceFilter.test.tsx` | Skeleton, dropdown, onChange, valore selezionato |

**Playwright (`npm run test:e2e`)**
- Caricamento: skeleton → eventi / errore / stato vuoto
- Filtro province: rendering, selezione, reset
- Scheda evento: distanze, pulsante poster
- Header: comportamento scroll

## Test plan

- [ ] `cd frontend && npm test -- --watchAll=false` → 36 test verdi
- [ ] `cd frontend && npm run test:e2e` → 13 test verdi (avvia il dev server automaticamente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)