### PR TITLE
refactor(scraper): BaseScraper condivide run() e _save_event()

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/test-results
 
 # production
 /build

--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -4,4 +4,3 @@ pydantic>=2.0.0
 supabase>=2.0.0
 python-dotenv>=1.0.0
 img2pdf>=0.4.0
-``` 

--- a/scraper/scrapers/base.py
+++ b/scraper/scrapers/base.py
@@ -3,23 +3,73 @@ Base scraper class defining the interface for all scrapers.
 """
 from abc import ABC, abstractmethod
 from typing import Tuple
+from scraper.models.event import Event
+from scraper.models.operation import Operation
+from scraper.db.supabase_client import SupabaseManager
 
 
 class BaseScraper(ABC):
     """Abstract base class for event scrapers."""
-    
-    @abstractmethod
-    def run(self) -> Tuple[int, int]:
-        """
-        Esegue lo scraping e salva su Supabase.
-        
-        Returns:
-            Tupla (eventi_inseriti, eventi_aggiornati)
-        """
-        pass
-    
+
     @property
     @abstractmethod
     def source_name(self) -> str:
-        """Nome della sorgente"""
+        """Nome della sorgente (es. 'CSI Bergamo')"""
         pass
+
+    @property
+    @abstractmethod
+    def organizer(self) -> str:
+        """Nome dell'organizzatore da salvare su Supabase"""
+        pass
+
+    @abstractmethod
+    def _fetch_events(self) -> list[Event]:
+        """Scarica e parsa gli eventi dalla sorgente. Implementato da ogni scraper."""
+        pass
+
+    def run(self) -> Tuple[int, int]:
+        """Esegue lo scraping e salva su Supabase. Comune a tutti gli scraper."""
+        events = self._fetch_events()
+
+        inserted = 0
+        updated = 0
+
+        for event in events:
+            result = self._save_event(event)
+            if result == Operation.INSERTED:
+                inserted += 1
+            elif result == Operation.UPDATED:
+                updated += 1
+
+        return (inserted, updated)
+
+    def _save_event(self, event: Event) -> Operation:
+        """Salva un evento su Supabase. Comune a tutti gli scraper."""
+        try:
+            location_id = SupabaseManager.upsert_location(
+                city=event.location.city,
+                province=event.location.province,
+                province_name=event.location.province_name,
+                region=event.location.region
+            )
+
+            operation = SupabaseManager.upsert_event(
+                name=event.title,
+                date=event.date,
+                location_id=location_id,
+                organizer=self.organizer,
+                url=None,
+                poster=event.poster,
+                distances=event.distances
+            )
+
+            if operation == Operation.INSERTED:
+                print(f"✅ Inserted: {event.title}")
+            else:
+                print(f"🔄 Updated: {event.title}")
+
+            return operation
+        except Exception as e:
+            print(f"❌ Failed: {event.title} - {e}")
+            return Operation.FAILED

--- a/scraper/scrapers/base.py
+++ b/scraper/scrapers/base.py
@@ -1,6 +1,7 @@
 """
 Base scraper class defining the interface for all scrapers.
 """
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Tuple
 from scraper.models.event import Event

--- a/scraper/scrapers/csi_scraper.py
+++ b/scraper/scrapers/csi_scraper.py
@@ -1,6 +1,7 @@
 """
 Scraper for CSI Bergamo events.
 """
+from __future__ import annotations
 import requests
 import img2pdf
 import re

--- a/scraper/scrapers/csi_scraper.py
+++ b/scraper/scrapers/csi_scraper.py
@@ -3,16 +3,14 @@ Scraper for CSI Bergamo events.
 """
 import requests
 import img2pdf
-import io
 import re
 import time
 import datetime
-from typing import Tuple, Optional
+from typing import Optional
 from bs4 import BeautifulSoup
 from scraper.scrapers.base import BaseScraper
 from scraper.models.event import Event
 from scraper.models.provinces import Province
-from scraper.models.operation import Operation
 from scraper.utils.parsers import parse_location
 from scraper.config import BASE_CSI_BERGAMO, CSI_LIST, REQUEST_DELAY, REQUEST_TIMEOUT
 from scraper.db.supabase_client import SupabaseManager
@@ -20,26 +18,14 @@ from scraper.db.supabase_client import SupabaseManager
 
 class CSIScraper(BaseScraper):
     """Scraper for CSI Bergamo walking events."""
-    
+
     @property
     def source_name(self) -> str:
         return "CSI Bergamo"
-    
-    def run(self) -> Tuple[int, int]:
-        """Esegue lo scraping e salva su Supabase"""
-        events = self._fetch_events()
-        
-        inserted = 0
-        updated = 0
-        
-        for event in events:
-            result = self._save_to_supabase(event)
-            if result == Operation.INSERTED:
-                inserted += 1
-            elif result == Operation.UPDATED:
-                updated += 1
-        
-        return (inserted, updated)
+
+    @property
+    def organizer(self) -> str:
+        return "CSI Bergamo"
     
     def _fetch_events(self) -> list[Event]:
         """Scarica eventi dal sito CSI"""
@@ -203,32 +189,3 @@ class CSIScraper(BaseScraper):
         
         return f"{day_str}/{month_str}/{year_str}"
 
-    def _save_to_supabase(self, event: Event) -> Operation:
-        """Salva evento su Supabase"""
-        try:
-            location_id = SupabaseManager.upsert_location(
-                city=event.location.city,
-                province=event.location.province,
-                province_name=event.location.province_name,
-                region=event.location.region
-            )
-            
-            operation = SupabaseManager.upsert_event(
-                name=event.title,
-                date=event.date,
-                location_id=location_id,
-                organizer="CSI Bergamo",
-                url=None,
-                poster=event.poster,
-                distances=event.distances
-            )
-            
-            if operation == Operation.INSERTED:
-                print(f"✅ Inserted: {event.title}")
-            else:
-                print(f"🔄 Updated: {event.title}")
-            
-            return operation
-        except Exception as e:
-            print(f"❌ Failed: {event.title} - {e}")
-            return Operation.FAILED

--- a/scraper/scrapers/fiasp_scraper.py
+++ b/scraper/scrapers/fiasp_scraper.py
@@ -1,6 +1,7 @@
 """
 Scraper for FIASP events.
 """
+from __future__ import annotations
 import requests
 from bs4 import BeautifulSoup
 from scraper.scrapers.base import BaseScraper

--- a/scraper/scrapers/fiasp_scraper.py
+++ b/scraper/scrapers/fiasp_scraper.py
@@ -3,37 +3,22 @@ Scraper for FIASP events.
 """
 import requests
 from bs4 import BeautifulSoup
-from typing import Tuple
 from scraper.scrapers.base import BaseScraper
 from scraper.models.event import Event
-from scraper.models.operation import Operation
 from scraper.utils.parsers import parse_location, parse_distances
 from scraper.config import FIASP_URL, REQUEST_TIMEOUT
-from scraper.db.supabase_client import SupabaseManager
 
 
 class FIASPScraper(BaseScraper):
     """Scraper for FIASP walking events."""
-    
+
     @property
     def source_name(self) -> str:
         return "FIASP Italia"
-    
-    def run(self) -> Tuple[int, int]:
-        """Esegue lo scraping e salva su Supabase"""
-        events = self._fetch_events()
-        
-        inserted = 0
-        updated = 0
-        
-        for event in events:
-            result = self._save_to_supabase(event)
-            if result == Operation.INSERTED:
-                inserted += 1
-            elif result == Operation.UPDATED:
-                updated += 1
-        
-        return (inserted, updated)
+
+    @property
+    def organizer(self) -> str:
+        return "FIASP Italia"
     
     def _fetch_events(self) -> list[Event]:
         """Scarica eventi dal sito FIASP"""
@@ -106,32 +91,3 @@ class FIASPScraper(BaseScraper):
         
         return a_tag["href"].strip()
     
-    def _save_to_supabase(self, event: Event) -> Operation:
-        """Salva evento su Supabase"""
-        try:
-            location_id = SupabaseManager.upsert_location(
-                city=event.location.city,
-                province=event.location.province,
-                province_name=event.location.province_name,
-                region=event.location.region
-            )
-            
-            operation = SupabaseManager.upsert_event(
-                name=event.title,
-                date=event.date,
-                location_id=location_id,
-                organizer="FIASP Italia",
-                url=None,
-                poster=event.poster,
-                distances=event.distances
-            )
-            
-            if operation == Operation.INSERTED:
-                print(f"✅ Inserted: {event.title}")
-            else:
-                print(f"🔄 Updated: {event.title}")
-            
-            return operation
-        except Exception as e:
-            print(f"❌ Failed: {event.title} - {e}")
-            return Operation.FAILED

--- a/scraper/utils/parsers.py
+++ b/scraper/utils/parsers.py
@@ -1,6 +1,7 @@
 """
 Parsing utilities for event data.
 """
+from __future__ import annotations
 import re
 from typing import List
 from scraper.models.event import Location


### PR DESCRIPTION
## Summary

- Sposta `run()` e la logica di salvataggio Supabase in `BaseScraper`, eliminando la duplicazione identica tra `CSIScraper` e `FIASPScraper`
- Aggiunge la proprietà astratta `organizer` (era una stringa hardcoded in ogni scraper)
- Ogni scraper ora implementa solo 3 cose: `source_name`, `organizer`, `_fetch_events()`

## Motivazione

Aggiungere una nuova sorgente in futuro richiede solo implementare `_fetch_events()` — tutta la logica comune (loop, salvataggio, log, contatori) è già nella base.

## Test plan

- [x] 36 test frontend passati (`npm test`)
- [ ] Verificare manualmente che lo scraper giri correttamente in produzione

🤖 Generated with [Claude Code](https://claude.com/claude-code)