### PR TITLE
feat(seo): meta tags, OG, sitemap, security headers e h1 header

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,31 +1,47 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="it">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg" type="image/svg+xml" />
     <link rel="alternate icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
+    <meta name="description" content="Tapasciate.it — il calendario delle manifestazioni podistiche non competitive in Italia. Trova le tapasciate nella tua provincia." />
+    <link rel="canonical" href="https://tapasciate.it/" />
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>Tapasciate.it</title>
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tapasciate.it/" />
+    <meta property="og:title" content="Tapasciate.it — Manifestazioni podistiche non competitive in Italia" />
+    <meta property="og:description" content="Il calendario delle tapasciate in Italia: manifestazioni podistiche non competitive. Cerca per provincia e data." />
+    <meta property="og:locale" content="it_IT" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Tapasciate.it — Manifestazioni podistiche non competitive in Italia" />
+    <meta name="twitter:description" content="Il calendario delle tapasciate in Italia: manifestazioni podistiche non competitive. Cerca per provincia e data." />
+
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>Tapasciate.it — Manifestazioni podistiche non competitive in Italia</title>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Tapasciate.it",
+      "url": "https://tapasciate.it/",
+      "description": "Il calendario delle tapasciate in Italia: manifestazioni podistiche non competitive. Cerca per provincia e data.",
+      "inLanguage": "it",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Tapasciate.it",
+        "url": "https://tapasciate.it/"
+      }
+    }
+    </script>
+
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -41,15 +57,5 @@
   <!-- End Google Tag Manager (noscript) -->
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+Sitemap: https://tapasciate.it/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://tapasciate.it/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://tapasciate.it/info.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://tapasciate.it/privacy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>

--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -14,6 +14,10 @@
   transition: padding 0.6s cubic-bezier(0, 0, 0.2, 1);
 }
 
+.site-title {
+  display: contents;
+}
+
 .logo {
   max-height: 400px;
   max-width: 800px;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -8,7 +8,9 @@ export default function Header({ scrolled = false }: Props) {
   return (
     <header className={`header${scrolled ? ' header--scrolled' : ''}`}>
       <div className="header-content">
-        <img src={process.env.PUBLIC_URL + '/header.svg'} alt="Logo Tapasciate" className="logo" />
+        <h1 className="site-title">
+          <img src={process.env.PUBLIC_URL + '/header.svg'} alt="Tapasciate" className="logo" />
+        </h1>
       </div>
     </header>
   )

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,22 @@
   command = "npm run build"
   publish = "build"
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+
 [[redirects]]
   from   = "/privacy"
   to     = "/privacy.html"
+  status = 200
+
+[[redirects]]
+  from   = "/info"
+  to     = "/info.html"
   status = 200
 
 [[redirects]]


### PR DESCRIPTION
## Cosa contiene

### SEO on-page
- `index.html`: `lang="it"`, title descrittivo, meta description, tag Open Graph (Facebook/LinkedIn), Twitter Card, URL canonical e JSON-LD `WebSite` per i rich results di Google

### Crawling e indicizzazione
- `robots.txt`: aggiunto il riferimento a `sitemap.xml`
- `sitemap.xml`: nuovo file con le tre URL del sito (home, info, privacy) e rispettive priorità e frequenza di aggiornamento

### Sicurezza
- `netlify.toml`: aggiunti security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`) e redirect `/info → /info.html`

### Header SEO + bug fix
- `Header.tsx`: l'`<img>` del logo è ora avvolto in `<h1>` — garantisce una gerarchia heading corretta per i crawler
- `Header.css`: `.site-title { display: contents }` — l'`<h1>` esiste nel DOM ma non altera il layout visivo. Fix rispetto al branch `feat/seo` precedente che usava `line-height: 0`, causando la scomparsa del logo.

## Test
Tutti i 36 test unitari/integrazione passano. I test E2E (Playwright) coprono il comportamento scroll dell'header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)